### PR TITLE
Added ability to equip the 'New Item' in the Item Compare screen. fixes #34

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,3 +109,7 @@ a:focus  { outline: none; -moz-outline-style: none; }
 .alt_ehp em:nth-child(2) {
     width: 30%;
 }
+
+.new-item th > button {
+    margin-left: 5px;
+}

--- a/js/Model/Item.js
+++ b/js/Model/Item.js
@@ -52,11 +52,29 @@ var Item = Backbone.Model.extend({
         this.trigger('change');
     },
 
+    hasNonDefaultValues: function() {
+        return _.any(this.getAllOptions(), function(o_info, o_name) {
+            if(this.get(o_name) != o_info['default']) {
+                return true;
+            }
+            return false;
+        }, this);
+    },
+
     reset : function () {
         _.each(this.getAllOptions(), function(o_info, o_name) {
             this.set(o_name, o_info['default']);
         }, this);
         
+        this.trigger('change');
+        this.save();
+    },
+
+    overwriteStatsWith : function (item) {
+        _.each(this.getAllOptions(), function(o_info, o_name) {
+            this.set(o_name, item.get(o_name))
+        }, this);
+
         this.trigger('change');
         this.save();
     }

--- a/js/View/SimulationView.js
+++ b/js/View/SimulationView.js
@@ -385,10 +385,11 @@ var SimulationView = Backbone.View.extend({
             newItem.on('change', function() { this.doItemCompare(itemslot); }, this);
 
             newItem.on('change', function() { this.validateNewItemEquippable(itemslot); }, this);
-            this.validateNewItemEquippable(itemslot);
 
             $('ul.slot-list', this.el).append($tab);
             $('div.slot-list', this.el).append($tabpane);
+            
+            this.validateNewItemEquippable(itemslot);
         }, this);
 
         $('ul.slot-list > li:first', this.el).addClass('active');


### PR DESCRIPTION
Couple things to note about the design here. 

I put the button on the New Item next to reset because it feels like you are really performing the action on the New Item. This simplifies the button, because it can merely say 'Equip' rather than 'Equip New Item' or something like that. 

I also decided that it makes sense to disable the button if 'New Item' has no changes (it is in the default state). This will help accidentally clicking Equip twice and overwriting your equipped item. I think that this will be good enough to prevent people from making mistakes, but I'm open to also having a dialog to confirm. However, dialogs can often be annoying, so I'd like it to not need one. That said, we might want to move it away from 'Reset' a little more.

Let me know what you think of these changes.
